### PR TITLE
info: Allow scanning Zork into a playlist

### DIFF
--- a/mojozork_libretro.info
+++ b/mojozork_libretro.info
@@ -19,6 +19,9 @@ savestate = "true"
 savestate_features = "serialized"
 cheats = "false"
 hw_render = "false"
+database = "Infocom - Z-Machine"
+
+# BIOS / Firmware
 notes = "MojoZork plays Infocom Z-Machine games up to version 3, which is most, but not all, of Infocom's catalog."
 
 description = "A Z-Machine emulator for playing text-based interactive fiction."


### PR DESCRIPTION
Having the `database` entry in the .info file allows RetroArch to scan for Zork games, and automatically add them to playlists. I've indexed the zork dat files from the official release on Infocom's website, along with what was provided by TOSEC: https://github.com/libretro/libretro-database/commit/42a4e01a6c65628a7e13101fd4a0be5fb041b6f2