### PR TITLE
ci: add Linux aarch64 libretro build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,6 +76,12 @@ libretro-build-linux-i686:
     - .libretro-linux-cmake-x86
     - .core-defs
 ﻿
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-cmake-aarch64
+    - .core-defs
+﻿
 # Windows 64-bit
 libretro-build-windows-x64:
   extends:


### PR DESCRIPTION
Adds a Linux ARM 64-bit job to the GitLab CI so the libretro buildbot produces an aarch64 build of this core, which is currently missing from https://buildbot.libretro.com/nightly/linux/aarch64/latest/ .

This is a CMake core, so no separate include is needed: `.libretro-linux-cmake-aarch64` is already defined inside the `/linux-cmake.yml` template that this file includes. The job just extends that class plus `.core-defs`, mirroring the existing `libretro-build-linux-x64` job.

The interpreter is portable C with no SIMD, JIT or endian assumptions, and arm64 is already exercised by the existing `osx-cmake-arm64`, iOS and tvOS jobs.

Verified locally on an aarch64 Linux machine (postmarketOS, glibc, GCC 15): `mojozork_libretro.so` builds warning-clean, loads in RetroArch 1.22.2, and runs `zork1.dat` correctly at 640x480 - status line, banner and the "West of House" opening all render, with a working input prompt.